### PR TITLE
update name of dixie.edu

### DIFF
--- a/world-universities.csv
+++ b/world-universities.csv
@@ -7586,7 +7586,7 @@ US,Dickinson College,http://www.dickinson.edu/
 US,Dickinson State University,http://www.dsu.nodak.edu/
 US,Dillard University,http://www.dillard.edu/
 US,Divine Word College,http://www.svd.org
-US,Dixie College,http://www.dixie.edu/
+US,Dixie State University,http://www.dixie.edu/
 US,Doane College,http://www.doane.edu/
 US,Dominican College,http://www.dc.edu/
 US,Dominican College of San Rafael,http://www.dominican.edu/


### PR DESCRIPTION
Dixie College was officially renamed Dixie State University a few years ago. The domain name is unchanged.
